### PR TITLE
add configuration for pvc storage based doclinks attachments upload

### DIFF
--- a/emm.env
+++ b/emm.env
@@ -70,6 +70,9 @@ ASK_ENV=1
 # A value of _ will discover the PVC from manage
 #OFFLINE_PVC=_
 
+# PersistentVolumeClaim for DocLinks if using PVC storage
+#DOCLINKS_PVC_NAME=a311548-mas-doclinks
+
 # Any variable prefixed with EMM_PROP_
 # will be copied to the final deployment
 # The startup script `setenv.sh` will pick these up

--- a/emm_install.sh
+++ b/emm_install.sh
@@ -751,6 +751,11 @@ $(echo "$(pass_emm_props)" | sed 's/^/            /')
             - name: internal-manage-tls
               readOnly: true
               mountPath: /etc/ssl/certs/internal-manage-tls
+$([[ -n "$DOCLINKS_PVC_NAME" ]] && cat << EOM
+            - name: doclinks-pvc
+              mountPath: /doclinks
+EOM
+)
 $([[ -n "$bundle_property" ]] && cat << EOM
             - name: bundle-properties
               mountPath: /config/manage/properties
@@ -774,6 +779,12 @@ EOM
           secret:
             secretName: $internal_manage_tls
             defaultMode: 420
+$([[ -n "$DOCLINKS_PVC_NAME" ]] && cat << EOM
+        - name: doclinks-pvc
+          persistentVolumeClaim:
+            claimName: $DOCLINKS_PVC_NAME
+EOM
+)
 $([[ -n "$bundle_property" ]] && cat << EOM
         - name: bundle-properties
           secret:


### PR DESCRIPTION
This adds the support for providing the DOCLINKS_PVC_NAME value for the PVC storage based doclinks attachments upload.